### PR TITLE
Tweak labels to have a period

### DIFF
--- a/src/components/confidentJoint/ConfidentJoint.tsx
+++ b/src/components/confidentJoint/ConfidentJoint.tsx
@@ -24,7 +24,7 @@ const ConfidentJoint = (props: ConfidentJointProps) => {
       rounded={'md'}
     >
       <HStack>
-        <Text>3</Text>
+        <Text>3.</Text>
         <Heading size={'sm'} fontWeight={500}>
           CONFIDENT JOINT MATRIX
         </Heading>

--- a/src/components/dataset/DatasetInterface.tsx
+++ b/src/components/dataset/DatasetInterface.tsx
@@ -26,7 +26,7 @@ const DatasetInterface = (props: DatasetInterfaceProps) => {
     >
       <VStack spacing={0}>
         <HStack>
-          <Text>1</Text>
+          <Text>1.</Text>
           <Heading size={'sm'} fontWeight={500}>
             CONSTRUCT DATASET
           </Heading>

--- a/src/components/predProbs/PredProbs.tsx
+++ b/src/components/predProbs/PredProbs.tsx
@@ -43,7 +43,7 @@ const PredProbs = (props: PredProbsProps) => {
         <Text fontSize={'md'}>Train the model in your browser!</Text>
       </HStack>
       <HStack>
-        <Text>2</Text>
+        <Text>2.</Text>
         <Heading size={'sm'} fontWeight={500}>
           PREDICTED PROBABILITIES
         </Heading>


### PR DESCRIPTION
Before:
<img width="1792" alt="Screen Shot 2022-08-07 at 2 07 23 PM" src="https://user-images.githubusercontent.com/3526486/183309373-f00d5a6f-f6bd-4593-a9b4-b7d085bb8d61.png">

After:

<img width="1791" alt="Screen Shot 2022-08-07 at 2 11 33 PM" src="https://user-images.githubusercontent.com/3526486/183309377-b5d3249c-8862-4e4f-b615-3116d34a0460.png">


I think this looks better, but it's a matter of opinion. Feel free to close if you like the old one more.
