### PR TITLE
Switch external links to anchors with href attr

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,14 +138,16 @@ export const App = () => {
               <HStack justify={'flex-end'} width={'100%'} spacing={1} height={'3%'}>
                 <Button variant={'ghost'}>Guide</Button>
                 <Button
+                  as="a"
                   variant={'ghost'}
-                  onClick={() => window.location.assign('https://github.com/cleanlab/vizzy')}
+                  href="https://cleanlab.ai/blog/cleanlab-vizzy/"
                 >
                   Blog
                 </Button>
                 <Button
+                  as="a"
                   variant={'ghost'}
-                  onClick={() => window.location.assign('https://github.com/cleanlab/vizzy')}
+                  href="https://github.com/cleanlab/vizzy"
                 >
                   GitHub
                 </Button>


### PR DESCRIPTION
This makes it so that users can, e.g., Cmd-click to open the links in a new tab.

Also, this patch fixes the URL for the blog post.