### PR TITLE
Tweak for better memoization (and better perf)

### DIFF
--- a/src/components/confidentJoint/ConfidentJointMatrix.tsx
+++ b/src/components/confidentJoint/ConfidentJointMatrix.tsx
@@ -41,25 +41,38 @@ const ConfidentJointMatrix = (props: ConfidentJointProps) => {
               {`given: ${labels[rowIdx]}`}
             </Tag>
           </Flex>
-          {[0, 1, 2].map((columnIdx) => (
-            <Box
-              borderWidth={'0.5px'}
-              m={0}
-              borderColor={'gray.500'}
-              w={cellSizePercent}
-              h={'100%'}
-            >
-              {issues && (
-                <ImageGrid
-                  suggestedLabel={labels[columnIdx]}
-                  givenLabel={labels[rowIdx]}
-                  activeImageId={activeImageId}
-                  setActiveImageId={setActiveImageId}
-                  issues={issues}
-                />
-              )}
-            </Box>
-          ))}
+          {[0, 1, 2].map((columnIdx) => {
+            const suggestedLabel = labels[columnIdx]
+            const givenLabel = labels[rowIdx]
+            const activeIssue = activeImageId && issues[activeImageId]
+            // if the active image ID doesn't fall within this grid, it doesn't
+            // need to know about it, improving memoization
+            const localActiveImageId =
+              activeImageId &&
+              activeIssue.givenLabel === givenLabel &&
+              activeIssue.suggestedLabel === suggestedLabel
+                ? activeImageId
+                : null
+            return (
+              <Box
+                borderWidth={'0.5px'}
+                m={0}
+                borderColor={'gray.500'}
+                w={cellSizePercent}
+                h={'100%'}
+              >
+                {issues && (
+                  <ImageGrid
+                    suggestedLabel={suggestedLabel}
+                    givenLabel={givenLabel}
+                    activeImageId={localActiveImageId}
+                    setActiveImageId={setActiveImageId}
+                    issues={issues}
+                  />
+                )}
+              </Box>
+            )
+          })}
         </HStack>
       ))}
     </VStack>

--- a/src/components/confidentJoint/ImageGrid.tsx
+++ b/src/components/confidentJoint/ImageGrid.tsx
@@ -23,7 +23,7 @@ const ImageGrid = (props: ImageGridProps) => {
               <LabelIssueImage
                 {...datapoint}
                 id={datapoint.id}
-                activeImageId={activeImageId}
+                isActive={datapoint.id === activeImageId}
                 setActiveImageId={setActiveImageId}
               />
             </GridItem>
@@ -33,4 +33,4 @@ const ImageGrid = (props: ImageGridProps) => {
   )
 }
 
-export default ImageGrid
+export default React.memo(ImageGrid)

--- a/src/components/issues/Issues.tsx
+++ b/src/components/issues/Issues.tsx
@@ -36,7 +36,7 @@ const Issues = (props: ResultsProps) => {
               <LabelIssueImage
                 {...datapoint}
                 id={datapoint.id}
-                activeImageId={activeImageId}
+                isActive={datapoint.id === activeImageId}
                 setActiveImageId={setActiveImageId}
               />
             </GridItem>

--- a/src/components/issues/LabelIssueImage.tsx
+++ b/src/components/issues/LabelIssueImage.tsx
@@ -3,8 +3,8 @@ import { Box, Image, Tag, VStack } from '@chakra-ui/react'
 import { LabelIssueImageProps } from './types'
 
 const LabelIssueImage = (props: LabelIssueImageProps) => {
-  const { id, givenLabel, suggestedLabel, activeImageId, setActiveImageId, ...imageProps } = props
-  if (id === activeImageId) {
+  const { id, givenLabel, suggestedLabel, isActive, setActiveImageId, ...imageProps } = props
+  if (isActive) {
     return (
       <Box position={'relative'} opacity={'85%'} onMouseEnter={() => setActiveImageId(id)}>
         <Image {...imageProps} rounded={'md'} />
@@ -19,4 +19,4 @@ const LabelIssueImage = (props: LabelIssueImageProps) => {
   }
 }
 
-export default LabelIssueImage
+export default React.memo(LabelIssueImage)

--- a/src/components/issues/types.tsx
+++ b/src/components/issues/types.tsx
@@ -11,6 +11,6 @@ export interface LabelIssueImageProps extends ImageProps {
   id: string
   givenLabel: string
   suggestedLabel: string
-  activeImageId?: string
+  isActive: boolean
   setActiveImageId: (string) => void
 }

--- a/src/components/ood/OutOfDistribution.tsx
+++ b/src/components/ood/OutOfDistribution.tsx
@@ -30,7 +30,7 @@ const OutOfDistribution = (props: OODProps) => {
               <LabelIssueImage
                 {...datapoint}
                 id={datapoint.id}
-                activeImageId={activeImageId}
+                isActive={datapoint.id === activeImageId}
                 setActiveImageId={setActiveImageId}
               />
             </GridItem>


### PR DESCRIPTION
Tweak for better memoization (and better perf)

With this patch:

- LabelIssueImage usually doesn't have to be re-rendered. This patch changes the props so it takes whether or not it's active, rather than taking the active ID, so we can memoize the result (a LabelIssueImage with an unrelated ID shouldn't be re-rendered if the active ID changes).
- ImageGrid usually doesn't have to be re-rendered, speeding up rendering of the ConfidentJointMatrix. This patch sets `activeImageId` to `null` when the active image falls within a different image grid, so memoization can be effective.

Benchmarked on my machine, this patch speeds up re-renders for:

- Moving the mouse around the confident joint matrix: from around 110 ms to around 40 ms (avoids re-rendering most ImageGrid and almost all LabelIssueImage)
- Moving the mouse around the images in the predicted probabilities table: from around 100 ms to around 55 ms (similar reason as above).
- Moving the OOD/class percentile sliders: from around 100 ms to around 45 ms (avoids re-rendering most LabelIssueImage).

