### PR TITLE
Highlight active image more prominently

### DIFF
--- a/src/components/issues/LabelIssueImage.tsx
+++ b/src/components/issues/LabelIssueImage.tsx
@@ -14,7 +14,7 @@ const LabelIssueImage = (props: LabelIssueImageProps) => {
     ...imageProps
   } = props
 
-  const activeBorderColor = useColorModeValue('gray.800', 'gray.100')
+  const activeBorderColor = useColorModeValue('gray.700', 'gray.200')
 
   const renderImage = () => {
     if (showGivenLabel) {


### PR DESCRIPTION
Highlight active image with a 2px colored border. One side effect is that the active image shrinks slightly (because the border takes up space). LMK if it looks bad to you. 